### PR TITLE
deploy to gh pages

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,4 +1,4 @@
-name: Build JupyterBook
+name: Deploy JupyterBook to GitHub pages
 
 on:
   pull_request:
@@ -37,3 +37,9 @@ jobs:
       - name: Build JupyterBook
         run: |
           jupyter-book build book/
+      - name: Deploy html files
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages # default: gh-pages
+          publish_dir: book/_build/html


### PR DESCRIPTION
- ci deployment to gh branch gh-pages using [peaciris](https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-set-another-github-pages-branch-publish_branch)